### PR TITLE
Use Develocity Maven extension

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -111,7 +111,7 @@ The following table shows the compatibility of the plugin version with Develocit
 |===
 |Bamboo Plugin version  | Develocity Maven extension version        | Common Custom User Data Maven extension version  | Minimum supported Develocity version
 |Next version           | 1.20.1                                    | 1.12.4                                           | 2023.4
-|2.0.0                  | 1.20.1                                    | 1.12.4                                           | 2023.4
+|2.0.0                  | 1.20.1                                    | 1.12.4                                           | 2024.1
 |1.3.0                  | 1.20.1                                    | 1.12.4                                           | 2023.4
 |1.2.0                  | 1.18.1                                    | 1.12.2                                           | 2023.2
 |1.1.2                  | 1.18.1                                    | 1.12.2                                           | 2023.2

--- a/README.adoc
+++ b/README.adoc
@@ -110,8 +110,8 @@ The following table shows the compatibility of the plugin version with Develocit
 
 |===
 |Bamboo Plugin version  | Develocity Maven extension version        | Common Custom User Data Maven extension version  | Minimum supported Develocity version
-|Next version           | 1.20.1                                    | 1.12.4                                           | 2023.4
-|2.0.0                  | 1.20.1                                    | 1.12.4                                           | 2024.1
+|Next version           | 1.21                                      | 1.12.4                                           | 2024.1
+|2.0.0                  | 1.20.1                                    | 1.12.4                                           | 2023.4
 |1.3.0                  | 1.20.1                                    | 1.12.4                                           | 2023.4
 |1.2.0                  | 1.18.1                                    | 1.12.2                                           | 2023.2
 |1.1.2                  | 1.18.1                                    | 1.12.2                                           | 2023.2

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <generated.java.sources.dir>${project.build.directory}/generated-sources/java</generated.java.sources.dir>
 
-        <develocity.maven.extension.version>1.20.1</develocity.maven.extension.version>
+        <develocity.maven.extension.version>1.21-rc-3</develocity.maven.extension.version>
         <ccud.maven.extension.version>1.12.4</ccud.maven.extension.version>
     </properties>
 
@@ -349,7 +349,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>com.gradle</groupId>
-                                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                                    <artifactId>develocity-maven-extension</artifactId>
                                     <version>${develocity.maven.extension.version}</version>
                                 </artifactItem>
                                 <artifactItem>
@@ -449,6 +449,10 @@
 
     <repositories>
         <repository>
+            <id>gradle-enterprise-libs-release-candidates</id>
+            <url>https://repo.grdev.net/artifactory/enterprise-libs-release-candidates-local/</url>
+        </repository>
+        <repository>
             <id>atlassian-public</id>
             <url>https://maven.atlassian.com/repository/public</url>
             <snapshots>
@@ -464,6 +468,10 @@
     </repositories>
 
     <pluginRepositories>
+        <pluginRepository>
+            <id>gradle-enterprise-libs-release-candidates</id>
+            <url>https://repo.grdev.net/artifactory/enterprise-libs-release-candidates-local/</url>
+        </pluginRepository>
         <pluginRepository>
             <id>atlassian-public</id>
             <url>https://maven.atlassian.com/repository/public</url>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 
         <generated.java.sources.dir>${project.build.directory}/generated-sources/java</generated.java.sources.dir>
 
+        <!-- CLEANUP: Update to released version of Maven extension -->
         <develocity.maven.extension.version>1.21-rc-3</develocity.maven.extension.version>
         <ccud.maven.extension.version>1.12.4</ccud.maven.extension.version>
     </properties>
@@ -448,6 +449,7 @@
     </profiles>
 
     <repositories>
+        <!-- CLEANUP: Remove gradle-dev-public repository when Maven extension is released-->
         <repository>
             <id>gradle-dev-public</id>
             <url>https://repo.grdev.net/artifactory/public</url>
@@ -468,6 +470,7 @@
     </repositories>
 
     <pluginRepositories>
+        <!-- CLEANUP: Remove gradle-dev-public plugin repository when Maven extension is released-->
         <pluginRepository>
             <id>gradle-dev-public</id>
             <url>https://repo.grdev.net/artifactory/public</url>

--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,8 @@
 
     <repositories>
         <repository>
-            <id>gradle-enterprise-libs-release-candidates</id>
-            <url>https://repo.grdev.net/artifactory/enterprise-libs-release-candidates-local/</url>
+            <id>gradle-dev-public</id>
+            <url>https://repo.grdev.net/artifactory/public</url>
         </repository>
         <repository>
             <id>atlassian-public</id>
@@ -469,8 +469,8 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>gradle-enterprise-libs-release-candidates</id>
-            <url>https://repo.grdev.net/artifactory/enterprise-libs-release-candidates-local/</url>
+            <id>gradle-dev-public</id>
+            <url>https://repo.grdev.net/artifactory/public</url>
         </pluginRepository>
         <pluginRepository>
             <id>atlassian-public</id>

--- a/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
+++ b/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static com.gradle.develocity.bamboo.SystemProperty.SystemPropertyKeyWithDeprecatedKey.*;
+import static com.gradle.develocity.bamboo.SystemProperty.SimpleSystemPropertyKey.MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY;
 import static com.gradle.develocity.bamboo.utils.StringPredicates.endsWith;
 import static com.gradle.develocity.bamboo.utils.StringPredicates.eq;
 
@@ -104,10 +106,10 @@ public class MavenBuildScanInjector extends AbstractBuildScanInjector<MavenConfi
         ) {
             classpath.add(mavenEmbeddedResources.copy(MavenEmbeddedResources.Resource.DEVELOCITY_EXTENSION));
 
-            systemProperties.add(new SystemProperty("gradle.scan.uploadInBackground", "false"));
-            systemProperties.add(new SystemProperty("gradle.enterprise.url", config.server));
+            systemProperties.addAll(UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES.forValue(false));
+            systemProperties.addAll(SERVER_URL_SYSTEM_PROPERTIES.forValue(config.server));
             if (config.allowUntrustedServer) {
-                systemProperties.add(new SystemProperty("gradle.enterprise.allowUntrustedServer", "true"));
+                systemProperties.addAll(ALLOW_UNTRUSTED_SERVER_SYSTEM_PROPERTIES.forValue(true));
             }
         }
         if (config.injectCcudExtension && !existingMavenExtensions.hasExtension(CCUD_EXTENSION_MAVEN_COORDINATES)) {
@@ -120,7 +122,7 @@ public class MavenBuildScanInjector extends AbstractBuildScanInjector<MavenConfi
 
             registerDevelocityResources(buildContext, classpath.files());
 
-            systemProperties.add(new SystemProperty("maven.ext.class.path", mavenExtClasspath));
+            systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue(mavenExtClasspath));
 
             tasks.forEach(task ->
                     mavenOptsSetters

--- a/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
+++ b/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
@@ -99,7 +99,9 @@ public class MavenBuildScanInjector extends AbstractBuildScanInjector<MavenConfi
 
         Classpath classpath = new Classpath();
         List<SystemProperty> systemProperties = new ArrayList<>();
-        if (!existingMavenExtensions.hasExtension(DEVELOCITY_EXTENSION_MAVEN_COORDINATES)) {
+        if (!existingMavenExtensions.hasExtension(GRADLE_ENTERPRISE_EXTENSION_MAVEN_COORDINATES)
+                && !existingMavenExtensions.hasExtension(DEVELOCITY_EXTENSION_MAVEN_COORDINATES)
+        ) {
             classpath.add(mavenEmbeddedResources.copy(MavenEmbeddedResources.Resource.DEVELOCITY_EXTENSION));
 
             systemProperties.add(new SystemProperty("gradle.scan.uploadInBackground", "false"));

--- a/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
+++ b/src/main/java/com/gradle/develocity/bamboo/MavenBuildScanInjector.java
@@ -40,7 +40,8 @@ public class MavenBuildScanInjector extends AbstractBuildScanInjector<MavenConfi
             endsWith(ARTIFACTORY_MAVEN_3_TASK_KEY_SUFFIX)
         );
 
-    private static final MavenCoordinates DEVELOCITY_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
+    private static final MavenCoordinates GRADLE_ENTERPRISE_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension");
+    private static final MavenCoordinates DEVELOCITY_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "develocity-maven-extension");
     private static final MavenCoordinates CCUD_EXTENSION_MAVEN_COORDINATES = new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension");
 
     private final DevelocityAccessKeyExporter accessKeyExporter;

--- a/src/main/java/com/gradle/develocity/bamboo/MavenEmbeddedResources.java
+++ b/src/main/java/com/gradle/develocity/bamboo/MavenEmbeddedResources.java
@@ -37,8 +37,8 @@ public final class MavenEmbeddedResources {
     enum Resource {
 
         DEVELOCITY_EXTENSION(
-            "gradle-enterprise-maven-extension-" + Versions.DEVELOCITY_EXTENSION_VERSION + ".jar",
-            "gradle-enterprise-maven-extension.jar"
+            "develocity-maven-extension-" + Versions.DEVELOCITY_EXTENSION_VERSION + ".jar",
+            "develocity-maven-extension.jar"
         ),
 
         CCUD_EXTENSION(

--- a/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
+++ b/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
@@ -1,6 +1,6 @@
 package com.gradle.develocity.bamboo;
 
-final class SystemProperty {
+public final class SystemProperty {
 
     private final String key;
     private final String value;

--- a/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
+++ b/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
@@ -1,11 +1,69 @@
 package com.gradle.develocity.bamboo;
 
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
 public final class SystemProperty {
+
+    enum SimpleSystemPropertyKey {
+        MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY("maven.ext.class.path");
+
+        SimpleSystemPropertyKey(String key) {
+            this.key = key;
+        }
+
+        public SystemProperty forValue(String value) {
+            return new SystemProperty(key, value);
+        }
+
+        private final String key;
+    }
+
+    enum SystemPropertyKeyWithDeprecatedKey {
+
+        UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES("develocity.scan.uploadInBackground", "gradle.scan.uploadInBackground"),
+        SERVER_URL_SYSTEM_PROPERTIES("develocity.url", "gradle.enterprise.url"),
+        ALLOW_UNTRUSTED_SERVER_SYSTEM_PROPERTIES("develocity.allowUntrustedServer", "gradle.enterprise.allowUntrustedServer");
+
+        private final String develocityKey;
+
+        @Nullable
+        private final String deprecatedKey;
+
+        SystemPropertyKeyWithDeprecatedKey(String develocityKey, @Nullable String deprecatedKey) {
+            this.develocityKey = develocityKey;
+            this.deprecatedKey = deprecatedKey;
+        }
+
+        public Collection<SystemProperty> forValue(String value) {
+            return propertiesFor(value);
+        }
+
+        public Collection<SystemProperty> forValue(boolean value) {
+            return propertiesFor(Boolean.toString(value));
+        }
+
+        private Collection<SystemProperty> propertiesFor(@Nullable String value) {
+            Collection<SystemProperty> properties = new ArrayList<>();
+
+            String val = (value == null) ? "" : value;
+
+            properties.add(new SystemProperty(develocityKey, val));
+            if (deprecatedKey != null) {
+                properties.add(new SystemProperty(deprecatedKey, val));
+            }
+
+            return properties;
+        }
+
+    }
 
     private final String key;
     private final String value;
 
-    SystemProperty(String key, String value) {
+    private SystemProperty(String key, String value) {
         this.key = key;
         this.value = value;
     }
@@ -17,4 +75,5 @@ public final class SystemProperty {
     String asString() {
         return String.format("-D%s=%s", key, value);
     }
+
 }

--- a/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
+++ b/src/main/java/com/gradle/develocity/bamboo/SystemProperty.java
@@ -29,10 +29,9 @@ public final class SystemProperty {
 
         private final String develocityKey;
 
-        @Nullable
         private final String deprecatedKey;
 
-        SystemPropertyKeyWithDeprecatedKey(String develocityKey, @Nullable String deprecatedKey) {
+        SystemPropertyKeyWithDeprecatedKey(String develocityKey, String deprecatedKey) {
             this.develocityKey = develocityKey;
             this.deprecatedKey = deprecatedKey;
         }
@@ -51,9 +50,7 @@ public final class SystemProperty {
             String val = (value == null) ? "" : value;
 
             properties.add(new SystemProperty(develocityKey, val));
-            if (deprecatedKey != null) {
-                properties.add(new SystemProperty(deprecatedKey, val));
-            }
+            properties.add(new SystemProperty(deprecatedKey, val));
 
             return properties;
         }

--- a/src/test/java/com/gradle/develocity/bamboo/ArtifactoryMaven3TaskMavenOptsSetterTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/ArtifactoryMaven3TaskMavenOptsSetterTest.java
@@ -13,6 +13,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.gradle.develocity.bamboo.SystemProperty.SystemPropertyKeyWithDeprecatedKey.SERVER_URL_SYSTEM_PROPERTIES;
+import static com.gradle.develocity.bamboo.SystemProperty.SystemPropertyKeyWithDeprecatedKey.UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES;
+import static com.gradle.develocity.bamboo.SystemProperty.SimpleSystemPropertyKey.MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -29,9 +32,9 @@ public class ArtifactoryMaven3TaskMavenOptsSetterTest {
     @Test
     void mavenOpsAreSet() {
         List<SystemProperty> systemProperties = new ArrayList<>();
-        systemProperties.add(new SystemProperty("maven.ext.class.path", "test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
-        systemProperties.add(new SystemProperty("gradle.scan.uploadInBackground", "false"));
-        systemProperties.add(new SystemProperty("gradle.enterprise.url", "url"));
+        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
+        systemProperties.addAll(UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES.forValue(false));
+        systemProperties.addAll(SERVER_URL_SYSTEM_PROPERTIES.forValue("url"));
 
         TaskDefinition taskDefinition = new TaskDefinitionImpl(
             RandomUtils.nextLong(), RandomStringUtils.randomAscii(10), null, Collections.singletonMap("key", "value")
@@ -46,7 +49,13 @@ public class ArtifactoryMaven3TaskMavenOptsSetterTest {
         assertThat(configuration.get("key"), is(equalTo("value")));
         assertThat(
             configuration.get(ArtifactoryMaven3TaskMavenOptsSetter.MAVEN_OPTS_KEY),
-            is(equalTo("-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=url"))
+            is(equalTo(
+                    "-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar " +
+                            "-Ddevelocity.scan.uploadInBackground=false " +
+                            "-Dgradle.scan.uploadInBackground=false " +
+                            "-Ddevelocity.url=url " +
+                            "-Dgradle.enterprise.url=url"
+            ))
         );
     }
 

--- a/src/test/java/com/gradle/develocity/bamboo/ArtifactoryMaven3TaskMavenOptsSetterTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/ArtifactoryMaven3TaskMavenOptsSetterTest.java
@@ -32,7 +32,7 @@ public class ArtifactoryMaven3TaskMavenOptsSetterTest {
     @Test
     void mavenOpsAreSet() {
         List<SystemProperty> systemProperties = new ArrayList<>();
-        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
+        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/develocity-maven-extension-1.21.jar"));
         systemProperties.addAll(UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES.forValue(false));
         systemProperties.addAll(SERVER_URL_SYSTEM_PROPERTIES.forValue("url"));
 
@@ -50,7 +50,7 @@ public class ArtifactoryMaven3TaskMavenOptsSetterTest {
         assertThat(
             configuration.get(ArtifactoryMaven3TaskMavenOptsSetter.MAVEN_OPTS_KEY),
             is(equalTo(
-                    "-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar " +
+                    "-Dmaven.ext.class.path=test/path/develocity-maven-extension-1.21.jar " +
                             "-Ddevelocity.scan.uploadInBackground=false " +
                             "-Dgradle.scan.uploadInBackground=false " +
                             "-Ddevelocity.url=url " +

--- a/src/test/java/com/gradle/develocity/bamboo/DefaultMavenOptsSetterTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/DefaultMavenOptsSetterTest.java
@@ -37,7 +37,7 @@ public class DefaultMavenOptsSetterTest {
     void mavenOpsAreSet() {
         // given
         List<SystemProperty> systemProperties = new ArrayList<>();
-        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
+        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/develocity-maven-extension-1.21.jar"));
         systemProperties.addAll(UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES.forValue(false));
         systemProperties.addAll(SERVER_URL_SYSTEM_PROPERTIES.forValue("url"));
 
@@ -63,7 +63,7 @@ public class DefaultMavenOptsSetterTest {
                 equalTo(Constants.DEFAULT_TASK_ENVIRONMENT_VARIABLES_KEY),
                 equalTo(
                         "MAVEN_OPTS=\"" +
-                                "-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar " +
+                                "-Dmaven.ext.class.path=test/path/develocity-maven-extension-1.21.jar " +
                                 "-Ddevelocity.scan.uploadInBackground=false " +
                                 "-Dgradle.scan.uploadInBackground=false " +
                                 "-Ddevelocity.url=url " +

--- a/src/test/java/com/gradle/develocity/bamboo/DefaultMavenOptsSetterTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/DefaultMavenOptsSetterTest.java
@@ -15,6 +15,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.gradle.develocity.bamboo.SystemProperty.SystemPropertyKeyWithDeprecatedKey.SERVER_URL_SYSTEM_PROPERTIES;
+import static com.gradle.develocity.bamboo.SystemProperty.SystemPropertyKeyWithDeprecatedKey.UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES;
+import static com.gradle.develocity.bamboo.SystemProperty.SimpleSystemPropertyKey.MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -34,9 +37,9 @@ public class DefaultMavenOptsSetterTest {
     void mavenOpsAreSet() {
         // given
         List<SystemProperty> systemProperties = new ArrayList<>();
-        systemProperties.add(new SystemProperty("maven.ext.class.path", "test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
-        systemProperties.add(new SystemProperty("gradle.scan.uploadInBackground", "false"));
-        systemProperties.add(new SystemProperty("gradle.enterprise.url", "url"));
+        systemProperties.add(MAVEN_EXT_CLASS_PATH_SYSTEM_PROPERTY.forValue("test/path/gradle-enterprise-maven-extension-1.15.4.jar"));
+        systemProperties.addAll(UPLOAD_IN_BACKGROUND_SYSTEM_PROPERTIES.forValue(false));
+        systemProperties.addAll(SERVER_URL_SYSTEM_PROPERTIES.forValue("url"));
 
         TaskDefinition taskDefinition =
             new TaskDefinitionImpl(
@@ -58,7 +61,16 @@ public class DefaultMavenOptsSetterTest {
         assertThat(configuration,
             hasEntry(
                 equalTo(Constants.DEFAULT_TASK_ENVIRONMENT_VARIABLES_KEY),
-                equalTo("MAVEN_OPTS=\"-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=url\""))
+                equalTo(
+                        "MAVEN_OPTS=\"" +
+                                "-Dmaven.ext.class.path=test/path/gradle-enterprise-maven-extension-1.15.4.jar " +
+                                "-Ddevelocity.scan.uploadInBackground=false " +
+                                "-Dgradle.scan.uploadInBackground=false " +
+                                "-Ddevelocity.url=url " +
+                                "-Dgradle.enterprise.url=url" +
+                                "\""
+                )
+            )
         );
     }
 

--- a/src/test/java/com/gradle/develocity/bamboo/MavenEmbeddedResourcesTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/MavenEmbeddedResourcesTest.java
@@ -26,10 +26,11 @@ public class MavenEmbeddedResourcesTest {
      * Expected checksums can be found at:
      * https://repo1.maven.org/maven2/com/gradle/gradle-enterprise-maven-extension/<version>/gradle-enterprise-maven-extension-<version>.jar.md5
      * https://repo1.maven.org/maven2/com/gradle/common-custom-user-data-maven-extension/<version>/common-custom-user-data-maven-extension-<version>.jar.md5
+     * https://repo1.maven.org/maven2/com/gradle/common-custom-user-data-maven-extension/<version>/common-custom-user-data-maven-extension-<version>.jar.md5
      */
     @ParameterizedTest
     @CsvSource({
-            "DEVELOCITY_EXTENSION, 06d846e9a9193c7dae1b2a1f4b35f4fb",
+            "DEVELOCITY_EXTENSION, 4fca7e03271d9cca9fea301804178f86",
             "CCUD_EXTENSION, 9b2c37ec08b5c5008fee24796038eda3"
     })
     void copiesEmbeddedExtension(MavenEmbeddedResources.Resource resource, String expectedChecksum) throws Exception {

--- a/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
+++ b/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
@@ -130,7 +130,7 @@ public class MavenInjectionTest extends AbstractInjectionTest {
     }
 
     @Test
-    void buildScanNotPublishedWithoutAcceptingTos() {
+    void buildScanNotPublishedWithoutAcceptingTermsOfUse() {
         // given
         ensurePluginConfiguration(form -> form
             .setServer(PUBLIC_DEVELOCITY_SERVER)
@@ -154,7 +154,7 @@ public class MavenInjectionTest extends AbstractInjectionTest {
         assertThat(output, containsString("[INFO] BUILD SUCCESS"));
 
         assertThat(output, containsString("[INFO] The build scan was not published due to a configuration problem."));
-        assertThat(output, containsString("[INFO] The Gradle Terms of Service have not been agreed to."));
+        assertThat(output, containsString("[INFO] The Gradle Terms of Use have not been agreed to."));
     }
     @Test
     void extensionAlreadyAppliedInProjectAndBuildScanAttemptedToPublishToProjectConfiguredHost() {

--- a/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
+++ b/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
@@ -88,18 +88,24 @@ public class MavenInjectionTest extends AbstractInjectionTest {
         // when
         PlanResultKey planResultKey = triggerBuild(planKey, jobKey);
         waitForBuildToFinish(planResultKey);
-
-        // then
-        String buildScans = getBuildScansFromMetadata(planResultKey).orElse(null);
-        assertThat(buildScans, startsWith("https://gradle.com/s/"));
-
-        // and
         String output = bambooApi.getLog(planResultKey);
 
+        boolean isRc = output.contains("Release candidate versions are not accepted by this Develocity server");
+
+        // then
         assertThat(output, containsString("[INFO] BUILD SUCCESS"));
 
-        assertThat(output, containsString("[INFO] Publishing build scan..."));
-        assertThat(output, containsString("[INFO] https://gradle.com/s/"));
+        // and
+        if (!isRc) {
+            String buildScans = getBuildScansFromMetadata(planResultKey).orElse(null);
+            assertThat(buildScans, startsWith("https://gradle.com/s/"));
+        }
+
+        // and
+        if (!isRc) {
+            assertThat(output, containsString("[INFO] Publishing build scan..."));
+            assertThat(output, containsString("[INFO] https://gradle.com/s/"));
+        }
     }
 
     @Test

--- a/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
+++ b/src/test/java/it/com/gradle/develocity/bamboo/injection/MavenInjectionTest.java
@@ -90,6 +90,7 @@ public class MavenInjectionTest extends AbstractInjectionTest {
         waitForBuildToFinish(planResultKey);
         String output = bambooApi.getLog(planResultKey);
 
+        // CLEANUP: Remove isRc condition when Maven extension is released
         boolean isRc = output.contains("Release candidate versions are not accepted by this Develocity server");
 
         // then


### PR DESCRIPTION
This PR

* updates the embedded version of the Maven extension to `1.21-rc-3`
* configures system properties for both the old and new Maven extension

Before this PR can be merged:
* update embedded Maven extension to `1.21` once it is released (and remove Gradle's public repository as well)
* check that integration tests are all green, as soon as scans.gradle.org is updated to 2024.1 (at the moment, that instance doesn't accept the newest Maven extension version)
