### PR TITLE
Convert init-script based on reference implementation

### DIFF
--- a/src/main/java/com/gradle/develocity/bamboo/GradleBuildScanInjector.java
+++ b/src/main/java/com/gradle/develocity/bamboo/GradleBuildScanInjector.java
@@ -131,13 +131,17 @@ public class GradleBuildScanInjector extends AbstractBuildScanInjector<GradleCon
     private void prepareEnvironment(BuildContext buildContext, GradleConfiguration config) {
         VariableContext variableContext = buildContext.getVariableContext();
 
-        Objects.runIfNotNull(config.server, it -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_DEVELOCITY_URL", it));
-        Objects.runIfTrue(config.allowUntrustedServer, () -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_DEVELOCITY_ALLOW_UNTRUSTED_SERVER", "true"));
-        Objects.runIfNotNull(config.develocityPluginVersion, it -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_DEVELOCITY_PLUGIN_VERSION", it));
-        Objects.runIfNotNull(config.ccudPluginVersion, it -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_CCUD_PLUGIN_VERSION", it));
-        Objects.runIfNotNull(config.pluginRepository, it -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_GRADLE_PLUGIN_REPOSITORY_URL", it));
-        Objects.runIfTrue(config.enforceUrl, () -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_DEVELOCITY_ENFORCE_URL", "true"));
-        Objects.runIfTrue(config.gradleCaptureFileFingerprints, () -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true"));
+        variableContext.addLocalVariable("DEVELOCITY_INJECTION_ENABLED", "true");
+        variableContext.addLocalVariable("DEVELOCITY_INJECTION_INIT_SCRIPT_NAME", GradleEmbeddedResources.INIT_SCRIPT_NAME);
+        variableContext.addLocalVariable("DEVELOCITY_AUTO_INJECTION_CUSTOM_VALUE", "Bamboo");
+        Objects.runIfNotNull(config.server, it -> variableContext.addLocalVariable("DEVELOCITY_URL", it));
+        Objects.runIfTrue(config.enforceUrl, () -> variableContext.addLocalVariable("DEVELOCITY_ENFORCE_URL", "true"));
+        Objects.runIfTrue(config.allowUntrustedServer, () -> variableContext.addLocalVariable("DEVELOCITY_ALLOW_UNTRUSTED_SERVER", "true"));
+        Objects.runIfNotNull(config.develocityPluginVersion, it -> variableContext.addLocalVariable("DEVELOCITY_PLUGIN_VERSION", it));
+        Objects.runIfNotNull(config.ccudPluginVersion, it -> variableContext.addLocalVariable("CCUD_PLUGIN_VERSION", it));
+        Objects.runIfTrue(config.gradleCaptureFileFingerprints, () -> variableContext.addLocalVariable("DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true"));
+
+        Objects.runIfNotNull(config.pluginRepository, it -> variableContext.addLocalVariable("GRADLE_PLUGIN_REPOSITORY_URL", it));
         Objects.runIfNotNull(
                 config.pluginRepositoryCredentialName,
                 it -> {
@@ -148,8 +152,8 @@ public class GradleBuildScanInjector extends AbstractBuildScanInjector<GradleCon
                         if (credentials.getUsername() == null || credentials.getPassword() == null) {
                             LOGGER.warn("Plugin repository credentials {} do not have username or password set.", it);
                         } else {
-                            variableContext.addLocalVariable("DEVELOCITY_PLUGIN_GRADLE_PLUGIN_REPOSITORY_USERNAME", credentials.getUsername());
-                            variableContext.addLocalVariable("DEVELOCITY_PLUGIN_GRADLE_PLUGIN_REPOSITORY_PASSWORD", credentials.getPassword());
+                            variableContext.addLocalVariable("GRADLE_PLUGIN_REPOSITORY_USERNAME", credentials.getUsername());
+                            variableContext.addLocalVariable("GRADLE_PLUGIN_REPOSITORY_PASSWORD", credentials.getPassword());
                         }
                     }
                 }

--- a/src/main/java/com/gradle/develocity/bamboo/GradleEmbeddedResources.java
+++ b/src/main/java/com/gradle/develocity/bamboo/GradleEmbeddedResources.java
@@ -10,7 +10,7 @@ import java.nio.file.StandardCopyOption;
 
 public final class GradleEmbeddedResources {
 
-    private static final String INIT_SCRIPT_NAME = "develocity-init-script.gradle";
+    public static final String INIT_SCRIPT_NAME = "develocity-init-script.gradle";
 
     File copyInitScript(String home) {
         try (InputStream is = GradleEmbeddedResources.class.getResourceAsStream(String.format("/develocity/gradle/%s", INIT_SCRIPT_NAME))) {

--- a/src/main/resources/develocity/gradle/develocity-init-script.gradle
+++ b/src/main/resources/develocity/gradle/develocity-init-script.gradle
@@ -2,23 +2,36 @@ import org.gradle.util.GradleVersion
 
 // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
 
-// conditionally apply the Develocity / Build Scan plugin to the classpath so it can be applied to the build further down in this script
+// conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
 initscript {
     def isTopLevelBuild = !gradle.parent
     if (!isTopLevelBuild) {
         return
     }
 
+    def ENV_VAR_PREFIX = 'bamboo_'
     def getInputParam = { String name ->
-        def envVarName = "bamboo_${name.toUpperCase().replace('.', '_').replace('-', '_')}"
+        def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
         return System.getProperty(name) ?: System.getenv(envVarName)
     }
 
-    def pluginRepositoryUrl = getInputParam('develocity-plugin.gradle.plugin-repository.url')
-    def pluginRepositoryUsername = getInputParam('develocity-plugin.gradle.plugin-repository.username')
-    def pluginRepositoryPassword = getInputParam('develocity-plugin.gradle.plugin-repository.password')
-    def develocityPluginVersion = getInputParam('develocity-plugin.develocity.plugin.version')
-    def ccudPluginVersion = getInputParam('develocity-plugin.ccud.plugin.version')
+    def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+    def initScriptName = buildscript.sourceFile.name
+    if (requestedInitScriptName != initScriptName) {
+        return
+    }
+
+    // finish early if injection is disabled
+    def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+    if (gradleInjectionEnabled != "true") {
+        return
+    }
+
+    def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
+    def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
+    def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
+    def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -47,7 +60,7 @@ initscript {
     dependencies {
         if (develocityPluginVersion) {
             if (atLeastGradle5) {
-                if (GradleVersion.version(develocityPluginVersion).baseVersion >= GradleVersion.version("3.17")) {
+                if (GradleVersion.version(develocityPluginVersion) >= GradleVersion.version("3.17")) {
                     classpath "com.gradle:develocity-gradle-plugin:$develocityPluginVersion"
                 } else {
                     classpath "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion"
@@ -63,6 +76,7 @@ initscript {
     }
 }
 
+def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
 def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
 def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
@@ -72,7 +86,6 @@ def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
 def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
 
 def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
-def CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE = 'Bamboo'
 def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
 def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
 
@@ -81,17 +94,35 @@ if (!isTopLevelBuild) {
     return
 }
 
+def ENV_VAR_PREFIX = 'bamboo_'
 def getInputParam = { String name ->
-    def envVarName = "bamboo_${name.toUpperCase().replace('.', '_').replace('-', '_')}"
+    def envVarName = ENV_VAR_PREFIX + name.toUpperCase().replace('.', '_').replace('-', '_')
     return System.getProperty(name) ?: System.getenv(envVarName)
 }
 
-def develocityUrl = getInputParam('develocity-plugin.develocity.url')
-def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity-plugin.develocity.allow-untrusted-server'))
-def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity-plugin.develocity.enforce-url'))
-def develocityCaptureFileFingerprints = Boolean.parseBoolean(getInputParam('develocity-plugin.develocity.capture-file-fingerprints'))
-def develocityPluginVersion = getInputParam('develocity-plugin.develocity.plugin.version')
-def ccudPluginVersion = getInputParam('develocity-plugin.ccud.plugin.version')
+def requestedInitScriptName = getInputParam('develocity.injection.init-script-name')
+def initScriptName = buildscript.sourceFile.name
+if (requestedInitScriptName != initScriptName) {
+    logger.quiet("Ignoring init script '${initScriptName}' as requested name '${requestedInitScriptName}' does not match")
+    return
+}
+
+// finish early if injection is disabled
+def gradleInjectionEnabled = getInputParam("develocity.injection-enabled")
+if (gradleInjectionEnabled != "true") {
+    return
+}
+
+def develocityUrl = getInputParam('develocity.url')
+def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
+def develocityPluginVersion = getInputParam('develocity.plugin.version')
+def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
+def buildScanTermsOfUseUrl = getInputParam('develocity.terms-of-use.url')
+def buildScanTermsOfUseAgree = getInputParam('develocity.terms-of-use.agree')
+def ciAutoInjectionCustomValueValue = getInputParam('develocity.auto-injection.custom-value')
 
 def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
@@ -110,7 +141,7 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
     return
 }
 
-// register buildScanPublished listener and optionally apply the Develocity / Build Scan plugin
+// register buildScanPublished listener and optionally apply the Develocity plugin
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
         buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
@@ -125,15 +156,15 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $pluginClass via init script")
                     applyPluginExternally(pluginManager, pluginClass)
                     def rootExtension = dvOrGe(
-                            { develocity },
-                            { buildScan }
+                        { develocity },
+                        { buildScan }
                     )
                     def buildScanExtension = dvOrGe(
-                            { rootExtension.buildScan },
-                            { rootExtension }
+                        { rootExtension.buildScan },
+                        { rootExtension }
                     )
                     if (develocityUrl) {
-                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                        logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                         rootExtension.server = develocityUrl
                         rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
                     }
@@ -142,12 +173,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                         buildScanExtension.publishAlways()
                     }
                     // uploadInBackground not available for build-scan-plugin 1.16
-                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = false
-                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                     if (isAtLeast(develocityPluginVersion, '2.1') && atLeastGradle5) {
                         logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                         if (isAtLeast(develocityPluginVersion, '3.17')) {
-                            buildScanExtension.capture.fileFingerprints = develocityCaptureFileFingerprints
+                            buildScanExtension.capture.fileFingerprints.set(develocityCaptureFileFingerprints)
                         } else if (isAtLeast(develocityPluginVersion, '3.7')) {
                             buildScanExtension.capture.taskInputFiles = develocityCaptureFileFingerprints
                         } else {
@@ -157,7 +188,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
-                    logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                    logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                 }
 
                 pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
@@ -169,6 +200,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                         }
                     }
+
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                        buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+
                 }
 
                 pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
@@ -177,6 +214,11 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
+                    }
+
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
                     }
                 }
             }
@@ -200,7 +242,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 logger.lifecycle("Applying $pluginClass via init script")
                 applyPluginExternally(settings.pluginManager, pluginClass)
                 if (develocityUrl) {
-                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                    logger.lifecycle("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
                     eachDevelocitySettingsExtension(settings) { ext ->
                         ext.server = develocityUrl
                         ext.allowUntrustedServer = develocityAllowUntrustedServer
@@ -208,52 +250,62 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
 
                 eachDevelocitySettingsExtension(settings) { ext ->
-                    ext.buildScan.uploadInBackground = false
-                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                    ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                    ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, ciAutoInjectionCustomValueValue
                 }
 
                 eachDevelocitySettingsExtension(settings,
-                        { develocity ->
+                    { develocity ->
+                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
+                        develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
+                    },
+                    { gradleEnterprise ->
+                        gradleEnterprise.buildScan.publishAlways()
+                        if (isAtLeast(develocityPluginVersion, '2.1')) {
                             logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                            develocity.buildScan.capture.fileFingerprints = develocityCaptureFileFingerprints
-                        },
-                        { gradleEnterprise ->
-                            gradleEnterprise.buildScan.publishAlways()
-                            if (isAtLeast(develocityPluginVersion, '2.1')) {
-                                logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
-                                if (isAtLeast(develocityPluginVersion, '3.7')) {
-                                    gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
-                                } else {
-                                    gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
-                                }
+                            if (isAtLeast(develocityPluginVersion, '3.7')) {
+                                gradleEnterprise.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
+                            } else {
+                                gradleEnterprise.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
                             }
                         }
+                    }
                 )
             }
 
             if (develocityUrl && develocityEnforceUrl) {
-                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                logger.lifecycle("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer, captureFileFingerprints: $develocityCaptureFileFingerprints")
             }
 
             eachDevelocitySettingsExtension(settings,
-                    { develocity ->
-                        if (develocityUrl && develocityEnforceUrl) {
-                            develocity.server = develocityUrl
-                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
-                    },
-                    { gradleEnterprise ->
-                        if (develocityUrl && develocityEnforceUrl) {
-                            gradleEnterprise.server = develocityUrl
-                            gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
-                        }
+                { develocity ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        develocity.server = develocityUrl
+                        develocity.allowUntrustedServer = develocityAllowUntrustedServer
                     }
+
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        develocity.buildScan.termsOfUseUrl = buildScanTermsOfUseUrl
+                        develocity.buildScan.termsOfUseAgree = buildScanTermsOfUseAgree
+                    }
+                },
+                { gradleEnterprise ->
+                    if (develocityUrl && develocityEnforceUrl) {
+                        gradleEnterprise.server = develocityUrl
+                        gradleEnterprise.allowUntrustedServer = develocityAllowUntrustedServer
+                    }
+
+                    if (buildScanTermsOfUseUrl && buildScanTermsOfUseAgree) {
+                        gradleEnterprise.buildScan.termsOfServiceUrl = buildScanTermsOfUseUrl
+                        gradleEnterprise.buildScan.termsOfServiceAgree = buildScanTermsOfUseAgree
+                    }
+                }
             )
         }
 
         if (ccudPluginVersion) {
             if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
-                logger.quiet("Applying $CCUD_PLUGIN_CLASS via init script")
+                logger.lifecycle("Applying $CCUD_PLUGIN_CLASS via init script")
                 settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
             }
         }
@@ -293,14 +345,14 @@ static def eachDevelocitySettingsExtension(def settings, def dvAction, def geAct
     def DEVELOCITY_CONFIGURATION_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
 
     def dvExtensions = settings.extensions.extensionsSchema.elements
-            .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
-            .collect { settings[it.name] }
+        .findAll { it.publicType.concreteClass.name == DEVELOCITY_CONFIGURATION_CLASS }
+        .collect { settings[it.name] }
     if (!dvExtensions.empty) {
         dvExtensions.each(dvAction)
     } else {
         def geExtensions = settings.extensions.extensionsSchema.elements
-                .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
-                .collect { settings[it.name] }
+            .findAll { it.publicType.concreteClass.name == GRADLE_ENTERPRISE_EXTENSION_CLASS }
+            .collect { settings[it.name] }
         geExtensions.each(geAction)
     }
 }


### PR DESCRIPTION
Without any changes to behaviour, this PR refactors `develocity-init-script.gradle` to be
near-identical to the reference script held in https://github.com/gradle/develocity-ci-injection. This will enable us to automatically integrate any future script changes into
this repository.
