### PR TITLE
Set both Develocity and Gradle Enterprise Access Keys

### DIFF
--- a/src/main/i18n/develocity-bamboo-plugin.properties
+++ b/src/main/i18n/develocity-bamboo-plugin.properties
@@ -30,7 +30,7 @@ develocity.config.shared-credential-name=Shared credential name
 develocity.config.access-key-info=The access key must be in the <b>&lt;server host name&gt;=&lt;access key&gt;</b> format. For more details please refer to the <a href="https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration" target="_blank">documentation</a>.
 develocity.config.auto-injection-info=<div>To enable instrumentation for Gradle builds set the Develocity server URL and the desired version of the Develocity Gradle plugin.</div><div>To enable instrumentation for Maven builds set the Develocity server URL and select <em>Enables Develocity Maven extension auto-injection</em>.</div><div>For more details please refer to the <a href="https://github.com/gradle/develocity-bamboo-plugin#configuration" target="_blank">documentation</a>.</div>
 develocity.config.enforce-url=Enforce Develocity server URL
-develocity.config.enforce-url.description=Whether to enforce the Develocity server URL configured in this connection over a URL configured in the project's build.
+develocity.config.enforce-url.description=Whether to enforce the Develocity server URL configured in this connection over the one in the project.
 develocity.config.general.title=General settings
 develocity.config.general.vcs-repository-filter=Auto-injection Git VCS repository filters
 develocity.config.general.vcs-repository-filter.info=Newline-delimited set of rules in the form of +|-:repository_matching_keyword, for which to enable/disable Develocity Gradle plugin/Maven extension auto-injection.<br/>By default, all Git VCS repositories have auto-injection enabled.

--- a/src/main/java/com/gradle/develocity/bamboo/Constants.java
+++ b/src/main/java/com/gradle/develocity/bamboo/Constants.java
@@ -15,7 +15,8 @@ public final class Constants {
     // must have secret as part of the name, see com.atlassian.bamboo.util.PasswordMaskingUtils
     public static final String ACCESS_KEY = "develocity.secret.accessKey";
 
-    public static final String DEVELOCITY_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
+    public static final String DEVELOCITY_ACCESS_KEY = "DEVELOCITY_ACCESS_KEY";
+    public static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
 
     public static final String SPACE = " ";
 

--- a/src/main/java/com/gradle/develocity/bamboo/DevelocityAccessKeyExporter.java
+++ b/src/main/java/com/gradle/develocity/bamboo/DevelocityAccessKeyExporter.java
@@ -33,7 +33,10 @@ public class DevelocityAccessKeyExporter {
                         .stream()
                         .filter(setter -> setter.applies(task))
                         .findFirst()
-                        .ifPresent(setter -> setter.apply(task, Constants.DEVELOCITY_ACCESS_KEY, accessKey))));
+                        .ifPresent(setter -> {
+                            setter.apply(task, Constants.DEVELOCITY_ACCESS_KEY, accessKey);
+                            setter.apply(task, Constants.GRADLE_ENTERPRISE_ACCESS_KEY, accessKey);
+                        })));
     }
 
     private boolean isDevelocityAccessKey(VariableDefinitionContext context) {

--- a/src/main/java/com/gradle/develocity/bamboo/DevelocityPreJobAction.java
+++ b/src/main/java/com/gradle/develocity/bamboo/DevelocityPreJobAction.java
@@ -55,8 +55,8 @@ public class DevelocityPreJobAction implements PreJobAction {
         UsernameAndPassword credentials = credentialsProvider.findByName(sharedCredentialName).orElse(null);
         if (credentials == null) {
             LOGGER.warn(
-                    "Shared credentials with the name {} are not found. Environment variable {} will not be set",
-                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY
+                    "Shared credentials with the name {} are not found. Environment variables {} and {} will not be set",
+                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY, Constants.GRADLE_ENTERPRISE_ACCESS_KEY
             );
             return;
         }
@@ -65,8 +65,8 @@ public class DevelocityPreJobAction implements PreJobAction {
         String accessKey = credentials.getPassword();
         if (StringUtils.isBlank(accessKey)) {
             LOGGER.warn(
-                    "Shared credentials with the name {} do not have password set. Environment variable {} will not be set",
-                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY
+                    "Shared credentials with the name {} do not have password set. Environment variables {} and {} will not be set",
+                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY, Constants.GRADLE_ENTERPRISE_ACCESS_KEY
             );
             return;
         }
@@ -74,8 +74,8 @@ public class DevelocityPreJobAction implements PreJobAction {
         DevelocityAccessCredentials allKeys = DevelocityAccessCredentials.parse(accessKey);
         if (allKeys.isEmpty()) {
             LOGGER.warn(
-                    "Cannot parse access keys from {} shared credential. Environment variable {} will not be set",
-                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY
+                    "Cannot parse access keys from {} shared credential. Environment variables {} and {} will not be set",
+                    sharedCredentialName, Constants.DEVELOCITY_ACCESS_KEY, Constants.GRADLE_ENTERPRISE_ACCESS_KEY
             );
             return;
         }


### PR DESCRIPTION
This PR makes sure that we set both deprecated and new access key environment variables, such that they are picked by the respective agents that read them and avoid warning messages