### PR TITLE
Take into account allowUntrusted when changed at runtime

### DIFF
--- a/src/main/java/com/gradle/develocity/bamboo/DevelocityPreJobAction.java
+++ b/src/main/java/com/gradle/develocity/bamboo/DevelocityPreJobAction.java
@@ -26,18 +26,18 @@ public class DevelocityPreJobAction implements PreJobAction {
     private final PersistentConfigurationManager configurationManager;
     private final UsernameAndPasswordCredentialsProvider credentialsProvider;
     private final List<BuildScanInjector<? extends BuildToolConfiguration>> injectors;
-    private final ShortLivedTokenClient shortLivedTokenClient;
+    private final ShortLivedTokenClientFactory shortLivedTokenClientFactory;
 
     public DevelocityPreJobAction(
             PersistentConfigurationManager configurationManager,
             UsernameAndPasswordCredentialsProvider credentialsProvider,
             List<BuildScanInjector<? extends BuildToolConfiguration>> injectors,
-            ShortLivedTokenClient shortLivedTokenClient
+            ShortLivedTokenClientFactory shortLivedTokenClientFactory
     ) {
         this.configurationManager = configurationManager;
         this.credentialsProvider = credentialsProvider;
         this.injectors = injectors;
-        this.shortLivedTokenClient = shortLivedTokenClient;
+        this.shortLivedTokenClientFactory = shortLivedTokenClientFactory;
     }
 
     @Override
@@ -83,6 +83,7 @@ public class DevelocityPreJobAction implements PreJobAction {
         boolean isInjectionSupportedBuild = injectors.stream()
                 .anyMatch(i -> i.hasSupportedTasks(buildContext));
         if (isInjectionSupportedBuild) {
+            ShortLivedTokenClient shortLivedTokenClient = shortLivedTokenClientFactory.create(configuration);
             // If we know the URL or there's only one access key configured corresponding to the right URL
             if (allKeys.isSingleKey() || configuration.isEnforceUrl()) {
                 String hostnameFromServerUrl = getHostnameFromServerUrl(configuration.getServer());

--- a/src/main/java/com/gradle/develocity/bamboo/ShortLivedTokenClient.java
+++ b/src/main/java/com/gradle/develocity/bamboo/ShortLivedTokenClient.java
@@ -1,7 +1,6 @@
 package com.gradle.develocity.bamboo;
 
 import com.gradle.develocity.bamboo.config.PersistentConfiguration;
-import com.gradle.develocity.bamboo.config.PersistentConfigurationManager;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -9,8 +8,6 @@ import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -23,7 +20,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@Component
 public class ShortLivedTokenClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ShortLivedTokenClient.class);
@@ -35,14 +31,9 @@ public class ShortLivedTokenClient {
 
     private final OkHttpClient httpClient;
 
-    @Autowired
-    public ShortLivedTokenClient(PersistentConfigurationManager configurationManager) {
+    public ShortLivedTokenClient(PersistentConfiguration persistentConfiguration) {
         OkHttpClient.Builder builder = new OkHttpClient().newBuilder().callTimeout(10, TimeUnit.SECONDS);
-
-        boolean allowUntrusted = configurationManager.load()
-                .map(PersistentConfiguration::isAllowUntrustedServer)
-                .orElse(false);
-        if (allowUntrusted) {
+        if (persistentConfiguration.isAllowUntrustedServer()) {
             builder.hostnameVerifier((hostname, session) -> true);
             try {
                 TrustManager[] allTrustingTrustManager = createAllTrustingTrustManager();

--- a/src/main/java/com/gradle/develocity/bamboo/ShortLivedTokenClientFactory.java
+++ b/src/main/java/com/gradle/develocity/bamboo/ShortLivedTokenClientFactory.java
@@ -1,0 +1,16 @@
+package com.gradle.develocity.bamboo;
+
+import com.gradle.develocity.bamboo.config.PersistentConfiguration;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory is needed to create a new instance based on `allowUntrusted` which can be changed at runtime.
+ */
+@Component
+public class ShortLivedTokenClientFactory {
+
+    public ShortLivedTokenClient create(PersistentConfiguration configuration) {
+        return new ShortLivedTokenClient(configuration);
+    }
+
+}

--- a/src/test/java/com/gradle/develocity/bamboo/DevelocityPreJobActionTest.java
+++ b/src/test/java/com/gradle/develocity/bamboo/DevelocityPreJobActionTest.java
@@ -40,6 +40,7 @@ class DevelocityPreJobActionTest {
     private final VariableContext variableContext = mock(VariableContext.class);
 
     private final ShortLivedTokenClient mockShortLivedTokenClient = mock(ShortLivedTokenClient.class);
+    private final ShortLivedTokenClientFactory mockShortLivedTokenClientFactory = mock(ShortLivedTokenClientFactory.class);
 
     private final GradleBuildScanInjector gradleBuildScanInjector =
             new GradleBuildScanInjector(null, null, null, null, null);
@@ -49,7 +50,7 @@ class DevelocityPreJobActionTest {
                     new PersistentConfigurationManager(bandanaManager),
                     new UsernameAndPasswordCredentialsProvider(credentialsAccessor),
                     Collections.singletonList(gradleBuildScanInjector),
-                    mockShortLivedTokenClient
+                    mockShortLivedTokenClientFactory
             );
 
     @Test
@@ -149,6 +150,7 @@ class DevelocityPreJobActionTest {
         when(credentialsData.getPluginKey()).thenReturn(UsernameAndPassword.SHARED_USERNAME_PASSWORD_PLUGIN_KEY);
         when(credentialsData.getConfiguration()).thenReturn(Collections.singletonMap(UsernameAndPassword.PASSWORD, accessKey));
         when(mockShortLivedTokenClient.get(anyString(), any(), anyString())).thenReturn(Optional.empty());
+        when(mockShortLivedTokenClientFactory.create(any())).thenReturn(mockShortLivedTokenClient);
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
@@ -180,6 +182,7 @@ class DevelocityPreJobActionTest {
         when(credentialsData.getPluginKey()).thenReturn(UsernameAndPassword.SHARED_USERNAME_PASSWORD_PLUGIN_KEY);
         when(credentialsData.getConfiguration()).thenReturn(Collections.singletonMap(UsernameAndPassword.PASSWORD, accessKey));
         when(mockShortLivedTokenClient.get(anyString(), any(), any())).thenReturn(Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of("scans.gradle.com", shortLivedToken)));
+        when(mockShortLivedTokenClientFactory.create(any())).thenReturn(mockShortLivedTokenClient);
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
@@ -218,6 +221,7 @@ class DevelocityPreJobActionTest {
         when(credentialsData.getPluginKey()).thenReturn(UsernameAndPassword.SHARED_USERNAME_PASSWORD_PLUGIN_KEY);
         when(credentialsData.getConfiguration()).thenReturn(Collections.singletonMap(UsernameAndPassword.PASSWORD, accessKey));
         when(mockShortLivedTokenClient.get(anyString(), any(), any())).thenReturn(Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of("scans.gradle.com", shortLivedToken)));
+        when(mockShortLivedTokenClientFactory.create(any())).thenReturn(mockShortLivedTokenClient);
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
@@ -250,6 +254,7 @@ class DevelocityPreJobActionTest {
         when(credentialsData.getPluginKey()).thenReturn(UsernameAndPassword.SHARED_USERNAME_PASSWORD_PLUGIN_KEY);
         when(credentialsData.getConfiguration()).thenReturn(Collections.singletonMap(UsernameAndPassword.PASSWORD, accessKey));
         when(mockShortLivedTokenClient.get(anyString(), any(), any())).thenReturn(Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of("scans.gradle.com", shortLivedToken)));
+        when(mockShortLivedTokenClientFactory.create(any())).thenReturn(mockShortLivedTokenClient);
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))
@@ -285,6 +290,7 @@ class DevelocityPreJobActionTest {
         when(mockShortLivedTokenClient.get(anyString(), any(), any()))
                 .thenReturn(Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of("scans.gradle.com", shortLivedTokenA)))
                 .thenReturn(Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of("localhost", shortLivedTokenB)));
+        when(mockShortLivedTokenClientFactory.create(any())).thenReturn(mockShortLivedTokenClient);
 
         String credentialsName = RandomStringUtils.randomAlphanumeric(10);
         when(bandanaManager.getValue(any(BandanaContext.class), anyString()))

--- a/src/test/java/it/com/gradle/develocity/bamboo/ShortLivedTokenClientTest.java
+++ b/src/test/java/it/com/gradle/develocity/bamboo/ShortLivedTokenClientTest.java
@@ -3,7 +3,6 @@ package it.com.gradle.develocity.bamboo;
 import com.gradle.develocity.bamboo.DevelocityAccessCredentials;
 import com.gradle.develocity.bamboo.ShortLivedTokenClient;
 import com.gradle.develocity.bamboo.config.PersistentConfiguration;
-import com.gradle.develocity.bamboo.config.PersistentConfigurationManager;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -33,7 +32,7 @@ import static org.mockito.Mockito.when;
 
 public class ShortLivedTokenClientTest implements AfterEachCallback {
 
-    private final ShortLivedTokenClient shortLivedTokenClient = new ShortLivedTokenClient(mock(PersistentConfigurationManager.class));
+    private final ShortLivedTokenClient shortLivedTokenClient = new ShortLivedTokenClient(mock(PersistentConfiguration.class));
 
     private EmbeddedApp mockDevelocityServer;
 
@@ -131,18 +130,10 @@ public class ShortLivedTokenClientTest implements AfterEachCallback {
                         .handlers(c -> c.post("api/auth/token", ctx -> ctx.getResponse().status(200).send(shortLivedToken)))
         );
 
-        PersistentConfigurationManager mockPersistentConfigurationManager = mock(PersistentConfigurationManager.class);
-        if (allowUntrusted) {
-            PersistentConfiguration mockPersistentConfiguration = mock(PersistentConfiguration.class);
-            when(mockPersistentConfiguration.isAllowUntrustedServer()).thenReturn(true);
-            when(mockPersistentConfigurationManager.load()).thenReturn(Optional.of(mockPersistentConfiguration));
-        } else {
-            PersistentConfiguration mockPersistentConfiguration = mock(PersistentConfiguration.class);
-            when(mockPersistentConfiguration.isAllowUntrustedServer()).thenReturn(false);
-            when(mockPersistentConfigurationManager.load()).thenReturn(Optional.of(mockPersistentConfiguration));
-        }
+        PersistentConfiguration mockPersistentConfiguration = mock(PersistentConfiguration.class);
+        when(mockPersistentConfiguration.isAllowUntrustedServer()).thenReturn(allowUntrusted);
 
-        ShortLivedTokenClient shortLivedTokenClient = new ShortLivedTokenClient(mockPersistentConfigurationManager);
+        ShortLivedTokenClient shortLivedTokenClient = new ShortLivedTokenClient(mockPersistentConfiguration);
         DevelocityAccessCredentials.HostnameAccessKey hostnameAccessKey = shortLivedTokenClient.get(
                 mockDevelocityServer.getAddress().toString(),
                 DevelocityAccessCredentials.HostnameAccessKey.of("localhost", "localhost=" + RandomStringUtils.randomAlphanumeric(30)),


### PR DESCRIPTION
Since `allowUntrusted` can be changed at runtime, we need to make sure we use a proper client.